### PR TITLE
Upgrade to use launch4j 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install [launch4j][l4j-home] somewhere on your local machine.
 
 [l4j-home]: http://launch4j.sourceforge.net/
 
-Put `[lein-launch4j "0.1.0-SNAPSHOT"]` into the `:plugins` vector of
+Put `[lein-launch4j "0.1.2-SNAPSHOT"]` into the `:plugins` vector of
 your `:user` profile.
 
 Then add `:launch4j-install-dir

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject lein-launch4j "0.1.1-SNAPSHOT"
+(defproject lein-launch4j "0.1.2-SNAPSHOT"
   :description "wrap your project with launch4j"
   :url "https://github.com/ezephyr/lein-launch4j"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[launch4j "3.0.2"]])
+  :dependencies [[net.sf.launch4j/launch4j "3.8.0"]])


### PR DESCRIPTION
Started using this today and it worked pretty well, except the executables I created would keep asking to install jre - upgraded to use launch4j 3.8 and everything working.  Are you planning on doing a release any time soon?
